### PR TITLE
Laravel compatibilty update

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,6 @@
 	],
 	"require": {
 		"scssphp/scssphp": "^1.1",
-		"facade/ignition": "^2.0",
 		"matthiasmullie/minify": "^1.3"
 	},
 	"require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
 	},
 	"require-dev": {
 		"phpunit/phpunit": "^9.3",
-		"orchestra/testbench": "^5.3"
+		"orchestra/testbench": "^5.0|^7.0|^8.0|^9.0"
 	},
 	"autoload": {
 		"psr-4": {

--- a/src/Engines/StyleViewCompilerEngine.php
+++ b/src/Engines/StyleViewCompilerEngine.php
@@ -2,7 +2,7 @@
 
 namespace BladeStyle\Engines;
 
-use Facade\Ignition\Views\Engines\CompilerEngine;
+use Illuminate\View\Engines\CompilerEngine;
 
 class StyleViewCompilerEngine extends CompilerEngine
 {


### PR DESCRIPTION
- Removed facade/ignition dependency (been removed from laravel since version 9)
- Using the (implicit) laravel/view dependency directly.